### PR TITLE
ci(action): enforces an upper limit of 5 open PRs by a single user

### DIFF
--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          core.setOutput(`User has ${{steps.get_prs.outputs.data.length-1}} existing Pull Requests open. g2g`);
+          console.log(`User has ${{steps.get_prs.outputs.data.length-1}} existing Pull Requests open. g2g`);
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}
       uses: actions/github-script@v6

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -20,6 +20,12 @@ jobs:
         repository: ${{ github.repository }}
         author: ${{ github.event.pull_request.user.login }}
         state: open
+    - name: Derp
+      if: ${{ steps.get_prs.outputs.data.length <= 5 }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          core.setOutput(`User has ${steps.get_prs.outputs.data.length-1} existing Pull Requests open. g2g`);
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}
       uses: actions/github-script@v6
@@ -32,7 +38,7 @@ jobs:
           }).then(response => response.data.some(label => label.name === 'hacktoberfest-accepted'));
 
           if (!hasHacktoberfestAcceptedLabel) {
-            const message = `You already have ${openPRs.data.length-1} other open pull requests. Please focus on completing those before opening new ones. Do not open additional PRs until those are resolved.`;
+            const message = `You already have ${steps.get_prs.outputs.data.length-1} other open pull requests. Please focus on completing those before opening new ones. Do not open additional PRs until those are resolved.`;
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -27,7 +27,7 @@ jobs:
           return openPRs.length;
     - name: Under Threshold
       if: ${{ steps.get_pr_count.outputs.result <= 5 }}
-      run: "echo User has '${{ steps.get_prs.outputs.data.length }}' counted PRs, including this one. g2g"
+      run: "echo User has '${{ steps.get_pr_count.outputs.result }}' counted PRs, including this one. g2g"
     - name: Fail if too many open PRs
       if: ${{ steps.get_pr_count.outputs.result > 5 }}
       uses: actions/github-script@v6

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -10,24 +10,26 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-    - name: Check open pull requests
+    - name: Get open PRs for user
+      id: get_prs
+      uses: octokit/request-action@v2.x
+      with: 
+        route: GET /repos/:repository/pulls
+        repository: ${{ github.repository }}
+        author: ${{ github.event.pull_request.user.login }}
+        state: open
+    - name: Fail if too many open PRs
+      if: ${{ steps.get_prs.outputs.data.length > 5 }}
       uses: actions/github-script@v6
       with:
         script: |
-          const openPRs = await github.rest.pulls.list({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            state: 'open',
-            author: context.payload.sender.login,
-          });
-
           const hasHacktoberfestAcceptedLabel = await github.rest.issues.listLabelsOnIssue({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.payload.pull_request.number,
           }).then(response => response.data.some(label => label.name === 'hacktoberfest-accepted'));
 
-          if (openPRs.data.length > 5 && !hasHacktoberfestAcceptedLabel) {
+          if (!hasHacktoberfestAcceptedLabel) {
             const message = `You already have ${openPRs.data.length-1} other open pull requests. Please focus on completing those before opening new ones. Do not open additional PRs until those are resolved.`;
             await github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          core.setOutput(`User has ${steps.get_prs.outputs.data.length-1} existing Pull Requests open. g2g`);
+          core.setOutput(`User has ${{steps.get_prs.outputs.data.length-1}} existing Pull Requests open. g2g`);
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}
       uses: actions/github-script@v6

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -22,6 +22,7 @@ jobs:
             state: 'open',
             author: context.payload.sender.login,
           });
+          console.log(openPRs);
           return openPRs.data.length;
     - name: Under Threshold
       if: ${{ steps.get_pr_count.outputs.result <= 5 }}

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -1,0 +1,39 @@
+name: Limit Open PRs
+
+on: 
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  limit_prs:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'approved') }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+    - name: Check open pull requests
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const openPRs = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            author: context.payload.sender.login,
+          });
+
+          const hasHacktoberfestAcceptedLabel = await github.rest.issues.listLabelsOnIssue({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.pull_request.number,
+          }).then(response => response.data.some(label => label.name === 'hacktoberfest-accepted'));
+
+          if (openPRs.data.length > 5 && !hasHacktoberfestAcceptedLabel) {
+            const message = `You already have ${openPRs.data.length-1} other open pull requests. Please focus on completing those before opening new ones. Do not open additional PRs until those are resolved.`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });
+            core.setFailed(message);
+          }

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -24,12 +24,12 @@ jobs:
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
       uses: actions/github-script@v6
       env:
-        OPEN_PR_COUNT: ${{ steps.get_prs.outputs.data.length }}
+        OPEN_PRS: ${{ steps.get_prs.outputs }}
       with:
         script: |
-          const { OPEN_PR_COUNT } = process.env;
-          console.log(OPEN_PR_COUNT);
-          const openPRct = parseInt(OPEN_PR_COUNT, 10);
+          const { OPEN_PRS} = process.env;
+          console.log(OPEN_PRS);
+          const openPRct = parseInt(OPEN_PR_COUNT.data.length, 10);
           console.log(`User has ${openPRct - 1} existing Pull Requests open. g2g`);
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -16,14 +16,15 @@ jobs:
       with:
         result-encoding: string
         script: |
-          const openPRs = await github.rest.pulls.list({
+          const openPRraw = await github.rest.pulls.list({
             owner: context.repo.owner,
             repo: context.repo.repo,
             state: 'open',
             author: context.payload.sender.login,
           });
+          const openPRs = openPRraw.data.filter(el => el.user.loign === context.payload.sender.login);
           console.log(openPRs);
-          return openPRs.data.length;
+          return openPRs.length;
     - name: Under Threshold
       if: ${{ steps.get_pr_count.outputs.result <= 5 }}
       run: "echo User has '${{ steps.get_prs.outputs.data.length }}' counted PRs, including this one. g2g"

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -20,7 +20,7 @@ jobs:
         repository: ${{ github.repository }}
         author: ${{ github.event.pull_request.user.login }}
         state: open
-    - name: Derp
+    - name: Under Threshold
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -13,6 +13,8 @@ jobs:
     - name: Get open PRs for user
       id: get_prs
       uses: octokit/request-action@v2.x
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with: 
         route: GET /repos/:repository/pulls
         repository: ${{ github.repository }}

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -24,12 +24,12 @@ jobs:
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
       uses: actions/github-script@v6
       env:
-        OPEN_PRS: "${{ steps.get_prs.outputs }}"
+        OPEN_PR_COUNT: "${{ steps.get_prs.outputs.data.length }}"
       with:
         script: |
-          const { OPEN_PRS} = process.env;
-          console.log(OPEN_PRS);
-          const openPRct = parseInt(OPEN_PR_COUNT.data.length, 10);
+          const { OPEN_PR_COUNT} = process.env;
+          console.log(OPEN_PR_COUNT);
+          const openPRct = parseInt(OPEN_PR_COUNT, 10);
           console.log(`User has ${openPRct - 1} existing Pull Requests open. g2g`);
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -11,7 +11,7 @@ jobs:
     permissions: write-all
     steps:
     - name: Check open pull requests
-      id: get_prs
+      id: get_pr_count
       uses: actions/github-script@v6
       with:
         result-encoding: string

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -23,9 +23,12 @@ jobs:
     - name: Under Threshold
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
       uses: actions/github-script@v6
+      env:
+        OPEN_PR_COUNT: ${{ steps.get_prs.outputs.data.length }}
       with:
         script: |
-          console.log(`User has ${{steps.get_prs.outputs.data.length-1}} existing Pull Requests open. g2g`);
+          const openPRct = parseInt(process.env.OPEN_PR_COUNT, 10);
+          console.log(`User has ${openPRct - 1} existing Pull Requests open. g2g`);
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}
       uses: actions/github-script@v6

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -24,12 +24,12 @@ jobs:
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
       uses: actions/github-script@v6
       env:
-        OPEN_PR_COUNT: ${{ steps.get_prs.outputs.data }}
+        OPEN_PR_COUNT: ${{ steps.get_prs.outputs.data.length }}
       with:
         script: |
-          const countOutput = process.env.OPEN_PR_COUNT;
-          console.log(countOutput);
-          const openPRct = parseInt(countOutput.length, 10);
+          const { OPEN_PR_COUNT } = process.env;
+          console.log(OPEN_PR_COUNT);
+          const openPRct = parseInt(OPEN_PR_COUNT, 10);
           console.log(`User has ${openPRct - 1} existing Pull Requests open. g2g`);
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -24,7 +24,7 @@ jobs:
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
       uses: actions/github-script@v6
       env:
-        OPEN_PRS: ${{ steps.get_prs.outputs }}
+        OPEN_PRS: "${{ steps.get_prs.outputs }}"
       with:
         script: |
           const { OPEN_PRS} = process.env;

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -22,7 +22,7 @@ jobs:
         state: open
     - name: Under Threshold
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
-      run: "User has '${{ steps.get_prs.outputs.data.length }}' counted PRs, including this one. g2g"
+      run: "echo User has '${{ steps.get_prs.outputs.data.length }}' counted PRs, including this one. g2g"
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}
       uses: actions/github-script@v6

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -24,10 +24,12 @@ jobs:
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
       uses: actions/github-script@v6
       env:
-        OPEN_PR_COUNT: ${{ steps.get_prs.outputs.data.length }}
+        OPEN_PR_COUNT: ${{ steps.get_prs.outputs.data }}
       with:
         script: |
-          const openPRct = parseInt(process.env.OPEN_PR_COUNT, 10);
+          const countOutput = process.env.OPEN_PR_COUNT;
+          console.log(countOutput);
+          const openPRct = parseInt(countOutput.length, 10);
           console.log(`User has ${openPRct - 1} existing Pull Requests open. g2g`);
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -22,15 +22,7 @@ jobs:
         state: open
     - name: Under Threshold
       if: ${{ steps.get_prs.outputs.data.length <= 5 }}
-      uses: actions/github-script@v6
-      env:
-        OPEN_PR_COUNT: "${{ steps.get_prs.outputs.data.length }}"
-      with:
-        script: |
-          const { OPEN_PR_COUNT} = process.env;
-          console.log(OPEN_PR_COUNT);
-          const openPRct = parseInt(OPEN_PR_COUNT, 10);
-          console.log(`User has ${openPRct - 1} existing Pull Requests open. g2g`);
+      run: "User has '${{ steps.get_prs.outputs.data.length }}' counted PRs, including this one. g2g"
     - name: Fail if too many open PRs
       if: ${{ steps.get_prs.outputs.data.length > 5 }}
       uses: actions/github-script@v6

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -22,7 +22,7 @@ jobs:
             state: 'open',
             author: context.payload.sender.login,
           });
-          const openPRs = openPRraw.data.filter(el => el.user.loign === context.payload.sender.login);
+          const openPRs = openPRraw.data.filter(el => el.user.login === context.payload.sender.login);
           console.log(openPRs);
           return openPRs.length;
     - name: Under Threshold

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -6,41 +6,37 @@ on:
 
 jobs:
   limit_prs:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'approved') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'hacktoberfest-accepted') }}
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-    - name: Get open PRs for user
+    - name: Check open pull requests
       id: get_prs
-      uses: octokit/request-action@v2.x
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with: 
-        route: GET /repos/:repository/pulls
-        repository: ${{ github.repository }}
-        author: ${{ github.event.pull_request.user.login }}
-        state: open
+      uses: actions/github-script@v6
+      with:
+        result-encoding: string
+        script: |
+          const openPRs = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            author: context.payload.sender.login,
+          });
+          return openPRs.data.length;
     - name: Under Threshold
-      if: ${{ steps.get_prs.outputs.data.length <= 5 }}
+      if: ${{ steps.get_pr_count.outputs.result <= 5 }}
       run: "echo User has '${{ steps.get_prs.outputs.data.length }}' counted PRs, including this one. g2g"
     - name: Fail if too many open PRs
-      if: ${{ steps.get_prs.outputs.data.length > 5 }}
+      if: ${{ steps.get_pr_count.outputs.result > 5 }}
       uses: actions/github-script@v6
       with:
         script: |
-          const hasHacktoberfestAcceptedLabel = await github.rest.issues.listLabelsOnIssue({
+          const prCount = parseInt(${{ steps.get_pr_count.outputs.result }},10);
+          const message = `You already have ${prCount-1} other open pull requests. Please focus on completing those before opening new ones. Do not open additional PRs until those are resolved.`;
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            issue_number: context.payload.pull_request.number,
-          }).then(response => response.data.some(label => label.name === 'hacktoberfest-accepted'));
-
-          if (!hasHacktoberfestAcceptedLabel) {
-            const message = `You already have ${steps.get_prs.outputs.data.length-1} other open pull requests. Please focus on completing those before opening new ones. Do not open additional PRs until those are resolved.`;
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: message
-            });
-            core.setFailed(message);
-          }
+            body: message
+          });
+          core.setFailed(message);

--- a/.github/workflows/limit-prs.yml
+++ b/.github/workflows/limit-prs.yml
@@ -23,7 +23,7 @@ jobs:
             author: context.payload.sender.login,
           });
           const openPRs = openPRraw.data.filter(el => el.user.login === context.payload.sender.login);
-          console.log(openPRs);
+          // console.log(openPRs);
           return openPRs.length;
     - name: Under Threshold
       if: ${{ steps.get_pr_count.outputs.result <= 5 }}


### PR DESCRIPTION
Not to punish or shame, but to manage the overwhelming amount of Pull Requests this project has seen this year.

It will:
- fail PRs when a submitter has an existing number of PRs at or above the threshold (currently 5)
- allows manual override with a label if needed
- provides a comment on the PR when the fail condition is triggered, as some have missed the check/action output